### PR TITLE
Fix Polish typo in success message

### DIFF
--- a/templates/Pages/list.php
+++ b/templates/Pages/list.php
@@ -17,7 +17,7 @@
         if (!empty($params['after'])) {
             switch ($params['after']) {
                 case 'created':
-                    echo '<div class="message">Notatka zostało utworzona</div>';
+                    echo '<div class="message">Notatka została utworzona</div>';
                     break;
                 case 'edited':
                     echo '<div class="message">Notatka została edytowana</div>';


### PR DESCRIPTION
## Summary
- fix Polish grammar in list page when a note is created

## Testing
- `composer install` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c075556c083238ac04b8616a86e0a